### PR TITLE
[PV3.4] Fixes a exception that blocks closing the property dialog

### DIFF
--- a/modules/org.pathvisio.core/src/org/pathvisio/core/model/PathwayElement.java
+++ b/modules/org.pathvisio.core/src/org/pathvisio/core/model/PathwayElement.java
@@ -1005,7 +1005,9 @@ public class PathwayElement implements GraphIdContainer, Comparable<PathwayEleme
 			}
 			else
 			{
-				setDataSource(DataSource.getExistingByFullName((String)value));
+				if (DataSource.fullNameExists((String)value)) {
+					setDataSource(DataSource.getExistingByFullName((String)value));
+				}
 			}
 			break;
 		case TYPE:


### PR DESCRIPTION
Before the patch, creating a `Complex` data node, with `Complex Portal` as data source but without identifier does not allow cancelling the dialog, with this exception staketrace:

```
Exception in thread "AWT-EventQueue-0" java.lang.IllegalArgumentException: No DataSource known for null
        at org.bridgedb.DataSource.getExistingByFullName(DataSource.java:827)
        at org.pathvisio.core.model.PathwayElement.setStaticProperty(PathwayElement.java:1008)
        at org.pathvisio.gui.dialogs.PathwayElementDialog.restoreState(PathwayElementDialog.java:119)
        at org.pathvisio.gui.dialogs.PathwayElementDialog.cancelPressed(PathwayElementDialog.java:200)
        at org.pathvisio.gui.dialogs.OkCancelDialog.actionPerformed(OkCancelDialog.java:128)
        at javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:2022)
        at javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2348)
        at javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:402)
        at javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:259)
        at javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:262)
        at java.awt.Component.processMouseEvent(Component.java:6539)
        at javax.swing.JComponent.processMouseEvent(JComponent.java:3324)
        at java.awt.Component.processEvent(Component.java:6304)
        at java.awt.Container.processEvent(Container.java:2239)
        at java.awt.Component.dispatchEventImpl(Component.java:4889)
        at java.awt.Container.dispatchEventImpl(Container.java:2297)
        at java.awt.Component.dispatchEvent(Component.java:4711)
        at java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4904)
        at java.awt.LightweightDispatcher.processMouseEvent(Container.java:4535)
        at java.awt.LightweightDispatcher.dispatchEvent(Container.java:4476)
        at java.awt.Container.dispatchEventImpl(Container.java:2283)
        at java.awt.Window.dispatchEventImpl(Window.java:2746)
        at java.awt.Component.dispatchEvent(Component.java:4711)
        at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:760)
        at java.awt.EventQueue.access$500(EventQueue.java:97)
        at java.awt.EventQueue$3.run(EventQueue.java:709)
        at java.awt.EventQueue$3.run(EventQueue.java:703)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
        at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:84)
        at java.awt.EventQueue$4.run(EventQueue.java:733)
        at java.awt.EventQueue$4.run(EventQueue.java:731)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
        at java.awt.EventQueue.dispatchEvent(EventQueue.java:730)
        at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205)
        at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
        at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:109)
        at java.awt.WaitDispatchSupport$2.run(WaitDispatchSupport.java:190)
        at java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:235)
        at java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:233)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.awt.WaitDispatchSupport.enter(WaitDispatchSupport.java:233)
        at java.awt.Dialog.show(Dialog.java:1084)
        at java.awt.Component.show(Component.java:1671)
        at java.awt.Component.setVisible(Component.java:1623)
        at java.awt.Window.setVisible(Window.java:1014)
        at java.awt.Dialog.setVisible(Dialog.java:1005)
        at org.pathvisio.gui.MainPanel.vPathwayEvent(MainPanel.java:475)
        at org.pathvisio.core.view.VPathway.fireVPathwayEvent(VPathway.java:2503)
        at org.pathvisio.core.view.VPathway.mouseDoubleClick(VPathway.java:934)
        at org.pathvisio.gui.view.VPathwaySwing.mouseClicked(VPathwaySwing.java:150)
        at java.awt.Component.processMouseEvent(Component.java:6542)
        at javax.swing.JComponent.processMouseEvent(JComponent.java:3324)
        at java.awt.Component.processEvent(Component.java:6304)
        at java.awt.Container.processEvent(Container.java:2239)
        at java.awt.Component.dispatchEventImpl(Component.java:4889)
        at java.awt.Container.dispatchEventImpl(Container.java:2297)
        at java.awt.Component.dispatchEvent(Component.java:4711)
        at java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4904)
        at java.awt.LightweightDispatcher.processMouseEvent(Container.java:4544)
        at java.awt.LightweightDispatcher.dispatchEvent(Container.java:4476)
        at java.awt.Container.dispatchEventImpl(Container.java:2283)
        at java.awt.Window.dispatchEventImpl(Window.java:2746)
        at java.awt.Component.dispatchEvent(Component.java:4711)
        at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:760)
        at java.awt.EventQueue.access$500(EventQueue.java:97)
        at java.awt.EventQueue$3.run(EventQueue.java:709)
        at java.awt.EventQueue$3.run(EventQueue.java:703)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
        at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:84)
        at java.awt.EventQueue$4.run(EventQueue.java:733)
        at java.awt.EventQueue$4.run(EventQueue.java:731)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
        at java.awt.EventQueue.dispatchEvent(EventQueue.java:730)
        at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205)
        at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
        at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
        at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
```

This patch checks first if the full name exists, and only then calls the `DataSource.getExistingByFullName()`, fixing the `IllegalArgumentException` to be thrown.